### PR TITLE
chore(pnpm): configure pnpm-test settings

### DIFF
--- a/package/pnpm-test/package.json
+++ b/package/pnpm-test/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pnpm-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "eslint-config-hijacking": "^2.4.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/package/pnpm-test/pnpm-lock.yaml
+++ b/package/pnpm-test/pnpm-lock.yaml
@@ -1,0 +1,194 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  eslint-config-hijacking:
+    specifier: ^2.4.0
+    version: 2.4.0(@sentry/angular@7.8.1)
+  react-dom:
+    specifier: ^18.2.0
+    version: 18.2.0(react@18.2.0)
+
+packages:
+
+  /@angular/common@14.3.0(@angular/core@14.3.0)(rxjs@7.8.1):
+    resolution: {integrity: sha512-pV9oyG3JhGWeQ+TFB0Qub6a1VZWMNZ6/7zEopvYivdqa5yDLLDSBRWb6P80RuONXyGnM1pa7l5nYopX+r/23GQ==}
+    engines: {node: ^14.15.0 || >=16.10.0}
+    peerDependencies:
+      '@angular/core': 14.3.0
+      rxjs: ^6.5.3 || ^7.4.0
+    dependencies:
+      '@angular/core': 14.3.0(rxjs@7.8.1)(zone.js@0.12.0)
+      rxjs: 7.8.1
+      tslib: 2.6.1
+    dev: false
+
+  /@angular/core@14.3.0(rxjs@7.8.1)(zone.js@0.12.0):
+    resolution: {integrity: sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==}
+    engines: {node: ^14.15.0 || >=16.10.0}
+    peerDependencies:
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.11.4 || ~0.12.0
+    dependencies:
+      rxjs: 7.8.1
+      tslib: 2.6.1
+      zone.js: 0.12.0
+    dev: false
+
+  /@angular/platform-browser@14.3.0(@angular/common@14.3.0)(@angular/core@14.3.0):
+    resolution: {integrity: sha512-w9Y3740UmTz44T0Egvc+4QV9sEbO61L+aRHbpkLTJdlEGzHByZvxJmJyBYmdqeyTPwc/Zpy7c02frlpfAlyB7A==}
+    engines: {node: ^14.15.0 || >=16.10.0}
+    peerDependencies:
+      '@angular/animations': 14.3.0
+      '@angular/common': 14.3.0
+      '@angular/core': 14.3.0
+    peerDependenciesMeta:
+      '@angular/animations':
+        optional: true
+    dependencies:
+      '@angular/common': 14.3.0(@angular/core@14.3.0)(rxjs@7.8.1)
+      '@angular/core': 14.3.0(rxjs@7.8.1)(zone.js@0.12.0)
+      tslib: 2.6.1
+    dev: false
+
+  /@angular/router@14.3.0(@angular/common@14.3.0)(@angular/core@14.3.0)(@angular/platform-browser@14.3.0)(rxjs@7.8.1):
+    resolution: {integrity: sha512-uip0V7w7k7xyxxpTPbr7EuMnYLj3FzJrwkLVJSEw3TMMGHt5VU5t4BBa9veGZOta2C205XFrTAHnp8mD+XYY1w==}
+    engines: {node: ^14.15.0 || >=16.10.0}
+    peerDependencies:
+      '@angular/common': 14.3.0
+      '@angular/core': 14.3.0
+      '@angular/platform-browser': 14.3.0
+      rxjs: ^6.5.3 || ^7.4.0
+    dependencies:
+      '@angular/common': 14.3.0(@angular/core@14.3.0)(rxjs@7.8.1)
+      '@angular/core': 14.3.0(rxjs@7.8.1)(zone.js@0.12.0)
+      '@angular/platform-browser': 14.3.0(@angular/common@14.3.0)(@angular/core@14.3.0)
+      rxjs: 7.8.1
+      tslib: 2.6.1
+    dev: false
+
+  /@sentry/angular@7.8.1(@angular/common@14.3.0)(@angular/core@14.3.0)(@angular/router@14.3.0)(rxjs@7.8.1):
+    resolution: {integrity: sha512-FROR+DJp9wiiakvOoar0A4cI+WcNORKcCOTx/ytF9n9vhr9YuG3DV30gO2aFv7q2iHfwlwFQulFTzRXYe6iTjg==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      '@angular/common': 10.x || 11.x || 12.x || 13.x || 14.x
+      '@angular/core': 10.x || 11.x || 12.x || 13.x || 14.x
+      '@angular/router': 10.x || 11.x || 12.x || 13.x || 14.x
+      rxjs: ^6.5.5 || ^7.x
+    dependencies:
+      '@angular/common': 14.3.0(@angular/core@14.3.0)(rxjs@7.8.1)
+      '@angular/core': 14.3.0(rxjs@7.8.1)(zone.js@0.12.0)
+      '@angular/router': 14.3.0(@angular/common@14.3.0)(@angular/core@14.3.0)(@angular/platform-browser@14.3.0)(rxjs@7.8.1)
+      '@sentry/browser': 7.8.1
+      '@sentry/types': 7.8.1
+      '@sentry/utils': 7.8.1
+      rxjs: 7.8.1
+      tslib: 2.6.1
+    dev: false
+
+  /@sentry/browser@7.8.1:
+    resolution: {integrity: sha512-9JuagYqHyaZu/4RqyxrAgEHo71oV592XBuUKC33gajCVKWbyG3mNqudSMoHtdM1DrV9REZ4Elha7zFaE2cJX6g==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.8.1
+      '@sentry/types': 7.8.1
+      '@sentry/utils': 7.8.1
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/core@7.8.1:
+    resolution: {integrity: sha512-PRivbdIzApi/gSixAxozhOBTylSVdw/9VxaStYHd7JJGhs36KXkV8ylpbCmYO4ap7/Ue9/slzwpvPOJJzmzAgA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/hub': 7.8.1
+      '@sentry/types': 7.8.1
+      '@sentry/utils': 7.8.1
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/hub@7.8.1:
+    resolution: {integrity: sha512-AxwyGyS9Lp4XsURu4t8opa5vZ+NAB6I/n+B/Uix3YZea9z8jdWYAu9vsXSizOrtxekc/i7ZN4bnlNgXVHix0iA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.8.1
+      '@sentry/utils': 7.8.1
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/types@7.8.1:
+    resolution: {integrity: sha512-LOoaeBXVI23Kh5SpIbxSRiJ6+eYZXVOFyPFH1T1mGBj95LPwRMqOdg0lUTmFJGBKbDGDB/YNjNnu1kQ7GrXBXw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@sentry/utils@7.8.1:
+    resolution: {integrity: sha512-isUZjft4HWTOk1Z58KFJ/zzXeFtIJgP82CkYQlW464ZR2WCqPHYlXXXRWZpOHOfMnrf+gWeX9WAGS9rTAdhiSg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.8.1
+      tslib: 1.14.1
+    dev: false
+
+  /eslint-config-hijacking@2.4.0(@sentry/angular@7.8.1):
+    resolution: {integrity: sha512-ZGLIuNTEiiEOZYt0eDNyb/W9LqJs0O4lOKsc9GqkqT2LH1GdefmhlKs8xdQxqJdUS/73sNyauezMQd4JGHVqWQ==}
+    peerDependencies:
+      '@sentry/angular': 7.8.1
+    dependencies:
+      '@sentry/angular': 7.8.1(@angular/common@14.3.0)(@angular/core@14.3.0)(@angular/router@14.3.0)(rxjs@7.8.1)
+      loose-envify: 1.1.0
+    dev: false
+
+  /js-tokens@1.0.3:
+    resolution: {integrity: sha512-SfeDkKyjCWzOfBEyjRcmtt4GUejT68lG5DL3+AkWFsyB5sJLcVs/Ucxk5vNjeg0qmQ/Js4jPJTzeqpaDB/6ZVg==}
+    dev: false
+
+  /loose-envify@1.1.0:
+    resolution: {integrity: sha512-4NSTa8hGGPR5GZqmiBXK5JbxPRzsfMXayx55AvpLGHvhsNiL01bToVMGiFxe4CBhBLJCil3Ek08q9+SNWiKlyg==}
+    dependencies:
+      js-tokens: 1.0.3
+    dev: false
+
+  /react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.1.0
+      react: 18.2.0
+      scheduler: 0.23.0
+    dev: false
+
+  /react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.1.0
+    dev: false
+
+  /rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.1.0
+    dev: false
+
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
+
+  /tslib@2.6.1:
+    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
+    dev: false
+
+  /zone.js@0.12.0:
+    resolution: {integrity: sha512-XtC+I5dXU14HrzidAKBNMqneIVUykLEAA1x+v4KVrd6AUPWlwYORF8KgsVqvgdHiKZ4BkxxjvYi/ksEixTPR0Q==}
+    dependencies:
+      tslib: 2.6.1
+    dev: false


### PR DESCRIPTION
## setting

## 현재 의존트리



<img width="390" alt="image" src="https://github.com/Ryan-Dia/nodePackageManager-test/assets/76567238/520c8b55-7147-4cac-958b-c52e11b3e2cd">

<br>
<br>
<br>
<br>

## 📌 1.  의존성이 호환되는 범위에서 버전 전체 통일

> 의존성에 맞게 패키지 설치 [관련 링크](https://docs.npmjs.com/cli/v9/configuring-npm/folders#cycles-conflicts-and-folder-parsimony)
```
Since foo depends directly on bar@1.2.3 and baz@1.2.3, those are installed in foo's node_modules folder.

Even though the latest copy of blerg is 1.3.7, foo has a specific dependency on version 1.2.5. 
```

> 예시
<img width="400" alt="image" src="https://github.com/Ryan-Dia/nodePackageManager-test/assets/76567238/0908c4fb-c22f-4023-a67f-884d3e2e55d0">
<img width="454" alt="image" src="https://github.com/Ryan-Dia/nodePackageManager-test/assets/76567238/3f61122f-b9ac-46f1-8f5d-725211ab8a38">


<img width="419" alt="image" src="https://github.com/Ryan-Dia/nodePackageManager-test/assets/76567238/f7be4d19-e7db-4df6-b627-f260c6617893">


<br>

`react-dom`의 packages.json을 보면 `loose-envify` 가 `^1.1.0`으로 의존성이 설정되어있어서 현재 최신버전인 `v1.4.0`이 설치되어야 하지만   `eslint-config-hijacking`이 `v1.1.0`으로 고정을 해놓아서 최신버전이아닌 `v1.1.0`으로 다운받아진것이다. 
이렇게 되면  하나의 라이브러리를 전체 공유할 수 있다.  단, 만약 `v1.1.0`미만의 버전을 다운 받으면  `v1.1.0`버전의 폴더가 추가로 생긴다






<img width="403" alt="image" src="https://github.com/Ryan-Dia/nodePackageManager-test/assets/76567238/a35e2a63-27de-480b-ba77-abd8bbd75923">

<br>
<br>
<br>

실제로 `node_modules`를 가보면 각각의 폴더마다 loose-envify가 설치된게 아니고 앞에서 설명했듯이 버전을 통일해서 최상위로 올려 필요한 곳에서 해당 라이브러리를 참조한다 
<img width="390" alt="image" src="https://github.com/Ryan-Dia/nodePackageManager-test/assets/76567238/d1054af9-9719-442d-b9b5-b86539abe1ca">

<br>

---

## 📌 2. peerDependencies 자동설치  

npm과 pnpm은 yarn과 다르게 패키지 설치시 peerDependencies도 같이 설치해준다.  

 
